### PR TITLE
Fix the way we retrieve the release store file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ ext.getReleaseSigningInfo = {
             keyPassword = System.console().readPassword("\nPlease enter the key password: ")
         }
 
-        if (storeFile == null || !storeFile.exists()) {
+        if (storeFile == null) {
             throw new InvalidUserDataException("Keystore path not specified or file does not exist")
         }
 


### PR DESCRIPTION
It may not be needed to check for the actual file existence,
since it will not be used in Debug builds.