### PR TITLE
Disable zoom by maxing min and max zoom the same

### DIFF
--- a/maoni/src/main/java/org/rm3l/maoni/ui/MaoniActivity.java
+++ b/maoni/src/main/java/org/rm3l/maoni/ui/MaoniActivity.java
@@ -364,7 +364,7 @@ public class MaoniActivity extends AppCompatActivity {
                             config.setShowCanvasBounds(true);
                             config.setStrokeWidth(57.0f);
                             config.setMinZoom(1.0f);
-                            config.setMaxZoom(3.0f);
+                            config.setMaxZoom(1.0f);
                             config.setStrokeColor(mHighlightColor);
                             final View decorView = getWindow().getDecorView();
                             config.setCanvasWidth(decorView.getWidth());


### PR DESCRIPTION
Zoom is strange as the underlying screenshot doesn't zoom with the drawable view.
So only the highlighting zooms, which isn't super helpful.
Additionally, figuring out _how_ it came that the view suddenly became bigger is
not a discoverable behavior.