### PR TITLE
Fix WORKING_DIR intent extra so that it always contains a String path.

### DIFF
--- a/maoni/src/main/java/org/rm3l/maoni/Maoni.java
+++ b/maoni/src/main/java/org/rm3l/maoni/Maoni.java
@@ -411,7 +411,7 @@ public class Maoni {
 
         maoniIntent.putExtra(WORKING_DIR,
                 maoniWorkingDir != null ?
-                        maoniWorkingDir : callerActivity.getCacheDir().getAbsolutePath());
+                        maoniWorkingDir.getAbsolutePath() : callerActivity.getCacheDir().getAbsolutePath());
 
         maoniIntent.putExtra(SCREEN_CAPTURING_FEATURE_ENABLED, screenCapturingFeatureEnabled);
         if (this.screenCapturingFeatureEnabled) {


### PR DESCRIPTION
When specifying a custom working directory, an error occurs on the Activity end of the Intent.
```logcat
W/Bundle: Attempt to cast generated internal exception:
          java.lang.ClassCastException: java.io.File cannot be cast to java.lang.String
              at android.os.BaseBundle.getString(BaseBundle.java:923)
              at android.content.Intent.getStringExtra(Intent.java:5403)
              at org.rm3l.maoni.ui.MaoniActivity.onCreate(MaoniActivity.java:169)
              ...
```

This is due to the Intent extra having a `File` object instead of the expected `String`.

This PR fixes the Intent input.