### PR TITLE
Dialog Screenshot

### DIFF
--- a/maoni-sample/src/main/java/org/rm3l/maoni/sample/ui/MaoniBottomSheetDialogFragment.kt
+++ b/maoni-sample/src/main/java/org/rm3l/maoni/sample/ui/MaoniBottomSheetDialogFragment.kt
@@ -1,0 +1,42 @@
+package org.rm3l.maoni.sample.ui
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import org.rm3l.maoni.Maoni
+import org.rm3l.maoni.sample.R
+import org.rm3l.maoni.sample.utils.MaoniUtils
+
+class MaoniBottomSheetDialogFragment : BottomSheetDialogFragment() {
+
+    private var maoni: Maoni? = null
+
+    override fun getTheme(): Int = R.style.RoundedBottomSheetDialog
+
+    override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
+    ): View? = inflater.inflate(
+            R.layout.bottom_sheet_dialog_fragment_maoni,
+            container,
+            false
+    )
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        view.findViewById<FloatingActionButton>(R.id.fab)
+                ?.setOnClickListener {
+                    maoni = MaoniUtils.buildMaoni(requireContext())
+                    maoni?.start(dialog)
+                }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        maoni?.clear()
+    }
+}

--- a/maoni-sample/src/main/java/org/rm3l/maoni/sample/ui/MaoniSampleMainActivity.java
+++ b/maoni-sample/src/main/java/org/rm3l/maoni/sample/ui/MaoniSampleMainActivity.java
@@ -22,24 +22,29 @@
 
 package org.rm3l.maoni.sample.ui;
 
+import android.app.Dialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
-import com.mikepenz.aboutlibraries.Libs;
 import com.mikepenz.aboutlibraries.LibsBuilder;
 
 import org.rm3l.maoni.Maoni;
 import org.rm3l.maoni.common.contract.Handler;
 import org.rm3l.maoni.sample.R;
 import org.rm3l.maoni.sample.extensions.ContextUtils;
+import org.rm3l.maoni.sample.utils.MaoniUtils;
 
 public class MaoniSampleMainActivity extends AppCompatActivity {
 
@@ -56,31 +61,11 @@ public class MaoniSampleMainActivity extends AppCompatActivity {
             setSupportActionBar(toolbar);
         }
 
-        final Handler handlerForMaoni = ContextUtils.getMaoniFeedbackHandler(this); //Custom handler for Maoni, which does nothing more than calling any of the maoni-* available callbacks
-        final Maoni.Builder maoniBuilder = ContextUtils.getMaoniFeedbackBuilder(this);
         final FloatingActionButton fab = findViewById(R.id.fab);
         if (fab != null) {
-            fab.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    // MaoniActivity de-registers handlers, listeners and validators upon activity destroy,
-                    // so we need to re-register it again by reconstructing a new Maoni instance.
-                    //Also, Maoni.start(...) cannot be called twice,
-                    // but we are reusing the Builder to construct a new instance along with its handler.
-                    //
-                    //Note that if no handler/listener is specified,
-                    //Maoni will fall back to opening an Email Intent, so your users can send
-                    //their feedback via email
-                  final SharedPreferences defaultSharedPreferences =
-                      PreferenceManager.getDefaultSharedPreferences(MaoniSampleMainActivity.this);
-                  mMaoni = maoniBuilder
-                        .withScreenCapturingFeature(defaultSharedPreferences
-                            .getBoolean("maoni_screen_capturing_enabled", true))
-                        .withLogsCapturingFeature(defaultSharedPreferences
-                            .getBoolean("maoni_logs_capturing_enabled", true))
-                        .withHandler(handlerForMaoni).build();
-                    mMaoni.start(MaoniSampleMainActivity.this);
-                }
+            fab.setOnClickListener(view -> {
+                mMaoni = MaoniUtils.buildMaoni(this);
+                mMaoni.start(MaoniSampleMainActivity.this);
             });
         }
     }
@@ -115,6 +100,9 @@ public class MaoniSampleMainActivity extends AppCompatActivity {
                     //start the activity
                     .start(this);
 
+        } else if (itemId == R.id.bottom_sheet) {
+            MaoniBottomSheetDialogFragment fragment = new MaoniBottomSheetDialogFragment();
+            fragment.show(getSupportFragmentManager(), "MaoniBottomSheetDialogFragment");
         }
         return super.onOptionsItemSelected(item);
     }

--- a/maoni-sample/src/main/java/org/rm3l/maoni/sample/utils/MaoniUtils.kt
+++ b/maoni-sample/src/main/java/org/rm3l/maoni/sample/utils/MaoniUtils.kt
@@ -1,0 +1,40 @@
+package org.rm3l.maoni.sample.utils
+
+import android.content.Context
+import android.preference.PreferenceManager
+import org.rm3l.maoni.Maoni
+import org.rm3l.maoni.common.contract.Handler
+import org.rm3l.maoni.sample.extensions.getMaoniFeedbackBuilder
+import org.rm3l.maoni.sample.extensions.getMaoniFeedbackHandler
+
+object MaoniUtils {
+
+    @JvmStatic
+    fun buildMaoni(context: Context): Maoni {
+        val handlerForMaoni: Handler = context.getMaoniFeedbackHandler() //Custom handler for Maoni, which does nothing more than calling any of the maoni-* available callbacks
+        val maoniBuilder: Maoni.Builder = context.getMaoniFeedbackBuilder()
+        // MaoniActivity de-registers handlers, listeners and validators upon activity destroy,
+        // so we need to re-register it again by reconstructing a new Maoni instance.
+        // Also, Maoni.start(...) cannot be called twice,
+        // but we are reusing the Builder to construct a new instance along with its handler.
+        //
+        //Note that if no handler/listener is specified,
+        //Maoni will fall back to opening an Email Intent, so your users can send
+        //their feedback via email
+        // MaoniActivity de-registers handlers, listeners and validators upon activity destroy,
+        // so we need to re-register it again by reconstructing a new Maoni instance.
+        // Also, Maoni.start(...) cannot be called twice,
+        // but we are reusing the Builder to construct a new instance along with its handler.
+        //
+        //Note that if no handler/listener is specified,
+        //Maoni will fall back to opening an Email Intent, so your users can send
+        //their feedback via email
+        val defaultSharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+        return maoniBuilder
+                .withScreenCapturingFeature(defaultSharedPreferences
+                        .getBoolean("maoni_screen_capturing_enabled", true))
+                .withLogsCapturingFeature(defaultSharedPreferences
+                        .getBoolean("maoni_logs_capturing_enabled", true))
+                .withHandler(handlerForMaoni).build()
+    }
+}

--- a/maoni-sample/src/main/res/layout/bottom_sheet_dialog_fragment_maoni.xml
+++ b/maoni-sample/src/main/res/layout/bottom_sheet_dialog_fragment_maoni.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include layout="@layout/content_maoni_sample_main" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="@dimen/fab_margin"
+        android:src="@drawable/ic_feedback_white_24dp" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/maoni-sample/src/main/res/layout/bottom_sheet_dialog_fragment_maoni.xml
+++ b/maoni-sample/src/main/res/layout/bottom_sheet_dialog_fragment_maoni.xml
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content">
 
-    <include layout="@layout/content_maoni_sample_main" />
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="10dp"
+        android:text="@string/main_activity_text"
+        android:textAppearance="?android:textAppearanceLarge"
+        android:textColor="@color/white" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab"
@@ -11,6 +19,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
         android:layout_margin="@dimen/fab_margin"
-        android:src="@drawable/ic_feedback_white_24dp" />
+        android:src="@drawable/ic_feedback_white_24dp"
+        app:tint="@color/white" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/maoni-sample/src/main/res/menu/menu_maoni_sample.xml
+++ b/maoni-sample/src/main/res/menu/menu_maoni_sample.xml
@@ -25,13 +25,18 @@ SOFTWARE.
     tools:context=".ui.MaoniSampleMainActivity">
     <item
         android:id="@+id/action_settings"
+        android:icon="@drawable/ic_maoni_sample_settings_white_24dp"
         android:orderInCategory="1"
         android:title="@string/action_settings"
-        app:showAsAction="ifRoom"
-        android:icon="@drawable/ic_maoni_sample_settings_white_24dp"/>
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/action_about"
         android:orderInCategory="100"
         android:title="@string/action_about"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/bottom_sheet"
+        android:orderInCategory="101"
+        android:title="@string/action_bottom_sheet"
         app:showAsAction="never" />
 </menu>

--- a/maoni-sample/src/main/res/values/strings.xml
+++ b/maoni-sample/src/main/res/values/strings.xml
@@ -64,4 +64,5 @@ SOFTWARE.
     <string name="how_to_send_feedback">How would you like to send your feedback?</string>
 
     <string name="action_settings">Settings</string>
+    <string name="action_bottom_sheet">Bottom Sheet</string>
 </resources>

--- a/maoni-sample/src/main/res/values/styles.xml
+++ b/maoni-sample/src/main/res/values/styles.xml
@@ -46,6 +46,7 @@ SOFTWARE.
 
     <style name="RoundedBottomSheetDialogStyle" parent="Widget.MaterialComponents.BottomSheet">
         <item name="shapeAppearanceOverlay">@style/RoundedBottomSheetDialogShapeOverlay</item>
+        <item name="backgroundTint">@color/maoni_black</item>
     </style>
 
     <style name="RoundedBottomSheetDialogShapeOverlay" parent="">

--- a/maoni-sample/src/main/res/values/styles.xml
+++ b/maoni-sample/src/main/res/values/styles.xml
@@ -40,4 +40,20 @@ SOFTWARE.
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
+    <style name="RoundedBottomSheetDialog" parent="@style/ThemeOverlay.MaterialComponents.BottomSheetDialog">
+        <item name="bottomSheetStyle">@style/RoundedBottomSheetDialogStyle</item>
+    </style>
+
+    <style name="RoundedBottomSheetDialogStyle" parent="Widget.MaterialComponents.BottomSheet">
+        <item name="shapeAppearanceOverlay">@style/RoundedBottomSheetDialogShapeOverlay</item>
+    </style>
+
+    <style name="RoundedBottomSheetDialogShapeOverlay" parent="">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSizeTopRight">16dp</item>
+        <item name="cornerSizeTopLeft">16dp</item>
+        <item name="cornerSizeBottomRight">0dp</item>
+        <item name="cornerSizeBottomLeft">0dp</item>
+    </style>
+
 </resources>

--- a/maoni/src/main/java/org/rm3l/maoni/Maoni.java
+++ b/maoni/src/main/java/org/rm3l/maoni/Maoni.java
@@ -23,11 +23,13 @@ package org.rm3l.maoni;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.app.Dialog;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.util.Log;
+import android.view.Window;
 
 import androidx.annotation.ColorRes;
 import androidx.annotation.DrawableRes;
@@ -224,12 +226,33 @@ public class Maoni {
     }
 
     /**
-     * Start the Maoni Activity
+     * Start the Maoni Activity. If screenCapturingFeatureEnabled is true this will take a
+     * screenshot of the activity window
      *
      * @param callerActivity the caller activity
      */
     public void start(@Nullable final Activity callerActivity) {
+        start(callerActivity, callerActivity.getWindow());
+    }
 
+    /**
+     * Start the Maoni Activity. If screenCapturingFeatureEnabled is true this will take a
+     * screenshot of the dialog window
+     *
+     * @param dialog the caller dialog
+     */
+    public void start(@Nullable Dialog dialog) {
+        Activity activity = ContextUtils.scanForActivity(dialog.getContext());
+        start(activity, dialog.getWindow());
+    }
+
+    /**
+     * Internal helper method used to start MaoniActivity
+     *
+     * @param callerActivity activity context
+     * @param window window for screen (if enabled)
+     */
+    private void start(Activity callerActivity, Window window) {
         if (mUsed.getAndSet(true)) {
             this.clear();
             throw new UnsupportedOperationException(
@@ -291,9 +314,9 @@ public class Maoni {
         if (this.screenCapturingFeatureEnabled) {
             //Create screenshot file
             final File screenshotFile = new File(maoniWorkingDir != null ? maoniWorkingDir : callerActivity.getCacheDir(),
-                MAONI_FEEDBACK_SCREENSHOT_FILENAME);
-            ViewUtils.exportViewToFile(callerActivity, callerActivity.getWindow().getDecorView(),
-                screenshotFile);
+                    MAONI_FEEDBACK_SCREENSHOT_FILENAME);
+            ViewUtils.exportViewToFile(callerActivity, window.getDecorView(),
+                    screenshotFile);
             maoniIntent.putExtra(SCREENSHOT_FILE, screenshotFile.getAbsolutePath());
 
             if (screenshotHint != null) {
@@ -362,7 +385,6 @@ public class Maoni {
 
         callerActivity.startActivity(maoniIntent);
     }
-
 
     public Maoni unregisterListener() {
         getInstance(context).setListener(null);

--- a/maoni/src/main/java/org/rm3l/maoni/Maoni.java
+++ b/maoni/src/main/java/org/rm3l/maoni/Maoni.java
@@ -314,9 +314,9 @@ public class Maoni {
         if (this.screenCapturingFeatureEnabled) {
             //Create screenshot file
             final File screenshotFile = new File(maoniWorkingDir != null ? maoniWorkingDir : callerActivity.getCacheDir(),
-                    MAONI_FEEDBACK_SCREENSHOT_FILENAME);
+                MAONI_FEEDBACK_SCREENSHOT_FILENAME);
             ViewUtils.exportViewToFile(callerActivity, window.getDecorView(),
-                    screenshotFile);
+                screenshotFile);
             maoniIntent.putExtra(SCREENSHOT_FILE, screenshotFile.getAbsolutePath());
 
             if (screenshotHint != null) {

--- a/maoni/src/main/java/org/rm3l/maoni/utils/ContextUtils.java
+++ b/maoni/src/main/java/org/rm3l/maoni/utils/ContextUtils.java
@@ -21,7 +21,9 @@
  */
 package org.rm3l.maoni.utils;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -53,8 +55,17 @@ public final class ContextUtils {
                     .getField(fieldName)
                     .get(null);
         } catch (final Exception e) {
-            //No worries
-            e.printStackTrace();
+            return null;
+        }
+    }
+
+    @Nullable
+    public static Activity scanForActivity(@NonNull final Context context) {
+        if (context instanceof Activity) {
+            return (Activity) context;
+        } else if (context instanceof ContextWrapper) {
+            return scanForActivity(((ContextWrapper) context).getBaseContext());
+        } else {
             return null;
         }
     }


### PR DESCRIPTION
Add the ability to pass a `Dialog` to `Maoni.start()`, which will take a screenshot of the `Dialog` window. I use `BottomSheetDialogFragment` pretty extensively for one of my apps, and it'd be nice if a user could capture feedback for the `Dialog` window as opposed to just the underlying `Activity`

<img src="https://user-images.githubusercontent.com/14003063/111924700-29651400-8a7c-11eb-8451-ee631944c472.gif" width=300 />